### PR TITLE
Don't trim starting character from path

### DIFF
--- a/src/DotnetCleanup/PathUtility.cs
+++ b/src/DotnetCleanup/PathUtility.cs
@@ -10,8 +10,7 @@ namespace DotnetCleanup
         public static string GetCleanPath(string path)
         {
             return path?.Replace('\\', SeparatorChar)
-                    .Replace('/', SeparatorChar)
-                    .TrimStart(SeparatorChar);
+                    .Replace('/', SeparatorChar);
         }
     }
 }


### PR DESCRIPTION
While using this tool on macOS, I was passing in a pull path (`/Users/stuart/git/...`), in this scenario we don't want to remove the first character. I can see how this would save people from an error if they are entering a relative path, but the responsibility should be on them to enter it correctly IMO.

Great tool by the way!