### PR TITLE
CI/CD concurrency dedup tweaks

### DIFF
--- a/.github/actions/dotnet-build-test/action.yml
+++ b/.github/actions/dotnet-build-test/action.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 
 name: .NET Build and Test
-description: Restore, build, and test the repository with Docker-backed integration tests.
+description: Set up the .NET SDK, then restore, build, and test the repository with Docker-backed integration tests.
 
 inputs:
   msbuild-properties:
@@ -16,6 +16,11 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Setup .NET
+    uses: actions/setup-dotnet@v5
+    with:
+      global-json-file: global.json
+
   - name: Docker Info
     shell: pwsh
     run: docker version && docker info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,5 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-      with:
-        global-json-file: global.json
-
     - name: .NET Build and Test
       uses: ./.github/actions/dotnet-build-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-      with:
-        global-json-file: global.json
-
     - name: Resolve Package Version
       id: version
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: publish-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
- ci: key concurrency on head_ref with ref fallback so a PR run and any branch-push run share a group and supersede each other on new pushes
- publish: cancel-in-progress=false so an in-flight release is never aborted mid nuget push